### PR TITLE
Add an option to limit the number of items shown on index

### DIFF
--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -22,7 +22,7 @@ By default, the attribute is rendered as an image tag.
   }
   </style>
   <% if field.index_display_preview? %>
-    <% field.data.each do |attachment| %>
+    <% field.preview_items.each do |attachment| %>
       <%= render partial: 'fields/active_storage/preview',
                 locals: {
                     field: field,

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -7,6 +7,14 @@ module Administrate
       class Engine < ::Rails::Engine
       end
 
+      def preview_items
+        if many? && index_preview_count
+          data.take(index_preview_count)
+        else
+          data
+        end
+      end
+
       def index_display_preview?
         options.fetch(:index_display_preview, true)
       end
@@ -17,6 +25,10 @@ module Administrate
 
       def index_display_count?
         options.fetch(:index_display_count) { attached? && attachments.count != 1 }
+      end
+
+      def index_preview_count
+        options[:index_preview_count]
       end
 
       def show_display_preview?


### PR DESCRIPTION
Set `.with_options(index_preview_count: n)` to display up to n images.

Example Usage:

```rb
    photos: Field::ActiveStorage.with_options(
      index_preview_count: 1, # can now display only one photo instead of all
      index_preview_size: [50, 50], show_preview_size: [150, 150],
      direct_upload: true,
      destroy_url: proc do |namespace, resource, attachment|
        [:photos, namespace, resource, { attachment_id: attachment.id} ]
      end
    ),
```